### PR TITLE
Lower mobile default zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -1424,8 +1424,8 @@
          * Initializes the application: parses data, populates UI elements, and renders the initial schedule.
          */
         function initializeApp() {
-            if (window.innerWidth < 768) { 
-                currentZoomLevel = 0.5; 
+            if (window.innerWidth < 768) {
+                currentZoomLevel = 0.4; // Default to 40% zoom on smaller screens
             } else {
                 currentZoomLevel = 1.0; 
             }


### PR DESCRIPTION
## Summary
- lower default zoom for small screens from 50% to 40%

## Testing
- `npm test` *(fails: no package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f518a881c83339b5a05cc3fdace06