### PR TITLE
Center individual schedule rotation cells

### DIFF
--- a/index.html
+++ b/index.html
@@ -1083,14 +1083,16 @@
             table.style.minWidth = '100%'; 
             const thead = document.createElement('thead');
             const tbody = document.createElement('tbody');
-            const individualHeaders = ['Week', 'Rotation/Activity']; 
+            const individualHeaders = ['Week', 'Rotation/Activity'];
             const headerRow = document.createElement('tr');
             individualHeaders.forEach(headerText => {
                 const th = document.createElement('th');
                 th.textContent = headerText;
-                if (headerText === 'Week') { 
+                if (headerText === 'Week') {
                     th.style.position = 'sticky'; th.style.left = '0';
                     th.style.zIndex = '12'; th.style.backgroundColor = '#000000';
+                } else if (headerText === 'Rotation/Activity') {
+                    th.style.textAlign = 'center';
                 }
                 headerRow.appendChild(th);
             });
@@ -1151,6 +1153,7 @@
 
                 const rotationCell = document.createElement('td');
                 rotationCell.innerHTML = rotationCellContent;
+                rotationCell.style.textAlign = 'center';
                 row.appendChild(rotationCell);
                 tbody.appendChild(row);
             });


### PR DESCRIPTION
## Summary
- center the Rotation/Activity column header and cells in the individual fellow schedule

## Testing
- `tidy -errors -q index.html`

------
https://chatgpt.com/codex/tasks/task_e_683f5aab77ec833389a3ce779409a700