### PR TITLE
Remove password upload step

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,18 @@ npm start
 
 ## Uploading schedule files
 
-Send a POST request to `/upload/:type` with `type` being either `main` or `call`. The request must include a `file` field containing the CSV and a `password` field set to `mizzou`.
+Send a POST request to `/upload/:type` with `type` being either `main` or `call`. The request must include a `file` field containing the CSV.
 
 Example using `curl`:
 
 ```bash
-curl -F "file=@main_schedule.csv" -F "password=mizzou" http://localhost:3000/upload/main
+curl -F "file=@main_schedule.csv" http://localhost:3000/upload/main
 ```
 
 Another example for uploading the call schedule:
 
 ```bash
-curl -F "file=@call_schedule.csv" -F "password=mizzou" http://localhost:3000/upload/call
+curl -F "file=@call_schedule.csv" http://localhost:3000/upload/call
 ```
 
 ## Git integration
@@ -55,6 +55,5 @@ Server logs are printed to stdout in the terminal running the server. The client
 only displays `Upload failed` when the server responds with an error status.
 Common causes include:
 
-- The provided password is incorrect.
 - Git is not installed on the machine.
 - The repository was never initialized with `git init`.

--- a/index.html
+++ b/index.html
@@ -421,7 +421,6 @@
     <script>
         let mainScheduleCsvData = '';
         let callScheduleCsvData = '';
-        let adminPassword = '';
 
         async function loadCsvData() {
             const [mainResp, callResp] = await Promise.all([
@@ -440,9 +439,6 @@
             }
             const formData = new FormData();
             formData.append('file', input.files[0]);
-            if (adminPassword) {
-                formData.append('password', adminPassword);
-            }
 
             const resp = await fetch(`/upload/${type}`, {
                 method: 'POST',
@@ -1416,15 +1412,9 @@
         });
 
         function handleAdminToggle() {
-            const pw = prompt('Enter admin password:');
-            if (pw === 'mizzou') {
-                adminPassword = pw;
-                if (uploadSection) uploadSection.classList.remove('hidden');
-                if (uploadInstructions) uploadInstructions.classList.remove('hidden');
-                if (adminToggleBtn) adminToggleBtn.classList.add('hidden');
-            } else {
-                alert('Incorrect password.');
-            }
+            if (uploadSection) uploadSection.classList.remove('hidden');
+            if (uploadInstructions) uploadInstructions.classList.remove('hidden');
+            if (adminToggleBtn) adminToggleBtn.classList.add('hidden');
         }
 
         /**

--- a/server.js
+++ b/server.js
@@ -15,11 +15,6 @@ app.use(express.static(REPO_DIR));
 
 app.post('/upload/:type', upload.single('file'), async (req, res) => {
   const { type } = req.params;
-  const { password } = req.body;
-  if (password !== 'mizzou') {
-    if (req.file) fs.unlinkSync(req.file.path);
-    return res.status(403).send('Invalid password.');
-  }
   if (!req.file) {
     return res.status(400).send('No file uploaded.');
   }


### PR DESCRIPTION
## Summary
- remove password check from server
- simplify admin upload flow in web UI
- drop password steps from README

## Testing
- `npm install`
- `npm start` (then killed)

------
https://chatgpt.com/codex/tasks/task_e_683f90499fc88333967ec4c2770151d3