### PR TITLE
Auto init git repo on startup

### DIFF
--- a/server.js
+++ b/server.js
@@ -11,6 +11,33 @@ const app = express();
 
 const REPO_DIR = path.resolve(__dirname);
 
+async function ensureGitRepo() {
+  const gitDir = path.join(REPO_DIR, '.git');
+  if (!fs.existsSync(gitDir)) {
+    await execAsync('git init', { cwd: REPO_DIR });
+  }
+  let name = '';
+  let email = '';
+  try {
+    const { stdout } = await execAsync('git config user.name', { cwd: REPO_DIR });
+    name = stdout.trim();
+  } catch (_) {}
+  try {
+    const { stdout } = await execAsync('git config user.email', { cwd: REPO_DIR });
+    email = stdout.trim();
+  } catch (_) {}
+  if (!name) {
+    await execAsync('git config user.name "Server User"', { cwd: REPO_DIR });
+  }
+  if (!email) {
+    await execAsync('git config user.email "server@example.com"', { cwd: REPO_DIR });
+  }
+}
+
+ensureGitRepo().catch(err => {
+  console.error('Failed to initialize git repository:', err);
+});
+
 app.use(express.static(REPO_DIR));
 
 app.post('/upload/:type', upload.single('file'), async (req, res) => {


### PR DESCRIPTION
## Summary
- add `ensureGitRepo` helper in server.js
- automatically initialize repo and set git user if missing

## Testing
- `npm install`
- `node server.js` (started server successfully)


------
https://chatgpt.com/codex/tasks/task_e_683f915cde688333b4406bdcfba18bab