### PR TITLE
Fix highlight color to match theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,8 +203,8 @@
         .highlight-md { background-color: #ef9a9a !important; } /* red-200 */
         
         /* Current week highlight */
-        .current-week-highlight td { background-color: #c8e6c9 !important; } /* Light green, ensure it overrides other backgrounds */
-        .current-week-highlight td:first-child { background-color: #c8e6c9 !important; } /* Ensure sticky column also gets highlighted */
+        .current-week-highlight td { background-color: var(--mizzou-hover-gold) !important; }
+        .current-week-highlight td:first-child { background-color: var(--mizzou-hover-gold) !important; }
         
         /* Call icon and asterisk */
         .call-icon-inline { margin-left: 0.25rem; font-size: 0.75em; }


### PR DESCRIPTION
## Summary
- update `current-week-highlight` style to use Mizzou theme colors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684119154a948333b20d45aca9cab660