### PR TITLE
Fix call date overlap with emoji

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,14 +210,16 @@
         .call-icon-inline {
             margin-left: 0.25rem;
             font-size: 0.75em;
-            display: inline-block;
+            display: inline-flex;
+            flex-direction: column;
+            align-items: center;
             line-height: 1;
-            text-align: center;
         }
         .call-date-range {
             display: block;
             font-size: 0.6em;
-            margin-top: -2px;
+            line-height: 1;
+            margin-top: 0;
         }
         .asterisk-note {
             color: #000000; /* Black for visibility */


### PR DESCRIPTION
## Summary
- update `.call-icon-inline` and `.call-date-range` styles to prevent the call date from overlapping the phone emoji

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685947b992308333b59d4bcb488afd85