### PR TITLE
Fix call icon layout on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,12 +214,13 @@
             flex-direction: column;
             align-items: center;
             line-height: 1;
+            min-width: 1.5em; /* Prevent icon and text from collapsing */
         }
         .call-date-range {
             display: block;
             font-size: 0.6em;
             line-height: 1;
-            margin-top: 0;
+            margin-top: 0.1em; /* Give a little space below the icon */
         }
         .asterisk-note {
             color: #000000; /* Black for visibility */


### PR DESCRIPTION
## Summary
- tweak `.call-icon-inline` so phone call emoji doesn't overlap call dates on mobile

## Testing
- `npm install puppeteer` *(fails: domain not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_685a0e3689b48333bb6d77170b204ffd