### PR TITLE
Subtle backup call indicators

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,12 +224,7 @@
         }
         .backup-call-icon-inline {
             margin-left: 0.25rem;
-            font-size: 0.75em;
-            display: inline-flex;
-            flex-direction: column;
-            align-items: center;
-            line-height: 1;
-            min-width: 1.5em;
+            font-size: 0.7em;
             color: #6b7280; /* gray-600 for subtle indication */
         }
         .asterisk-note {
@@ -381,7 +376,7 @@
                          <div class="legend-button-wrapper">
                             <button id="legend-toggle-btn">Legend ℹ️</button>
                             <div id="legend-popover" class="hidden absolute mt-1"> <p><span class="legend-symbol">📞</span> = On Call</p>
-                                <p><span class="legend-symbol" style="color:#6b7280;">📞B</span> = Backup Call</p>
+                                <p><span class="legend-symbol" style="color:#6b7280;">📞B</span> = Backup Call <small>(hover for dates)</small></p>
                                 <p class="mt-1"><em>Note: Call starts Friday 4:30 PM of the preceding week and ends Friday morning of the listed week.</em></p>
                                 <hr class="my-2">
                                 <p><strong>Specific Holiday Coverage:</strong></p>
@@ -1043,7 +1038,7 @@
                     // Add backup call icon if this fellow is backup
                     if (cellFellows.some(cf => ALL_FELLOWS.includes(cf) && cf === fellowOnBackupCallThisWeek)) {
                         const backupRangeStr = backupCallInfo ? backupCallInfo.callRange : '';
-                        cellHtml += ` <span class="backup-call-icon-inline">📞<span class="call-date-range">B ${backupRangeStr}</span></span>`;
+                        cellHtml += ` <span class="backup-call-icon-inline" title="Backup ${backupRangeStr}">📞B</span>`;
                     }
                     
                     // Add asterisk for specific holiday coverage
@@ -1202,7 +1197,7 @@
                 }
                 const backupCallInfoForWeek = backupCallScheduleMap[weekString];
                 if (backupCallInfoForWeek && fellowInitial === backupCallInfoForWeek.fellow) {
-                    rotationCellContent += ` <span class="backup-call-icon-inline">📞<span class="call-date-range">B ${backupCallInfoForWeek.callRange}</span></span>`;
+                    rotationCellContent += ` <span class="backup-call-icon-inline" title="Backup ${backupCallInfoForWeek.callRange}">📞B</span>`;
                 }
                 
                 let hasSpecificHolidayCoverage = false;


### PR DESCRIPTION
## Summary
- reduce size of backup call icon and drop date text
- add tooltip for backup call dates
- update legend to note hovering for dates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a13f236d08333a77698d34a3fe481