### PR TITLE
Add mobile-friendly call indicators

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,27 +206,66 @@
         .current-week-highlight td { background-color: var(--mizzou-hover-gold) !important; }
         .current-week-highlight td:first-child { background-color: var(--mizzou-hover-gold) !important; }
         
-        /* Call icon and asterisk */
-        .call-icon-inline {
-            margin-left: 0.25rem;
-            font-size: 0.75em;
+        /* Call/Backup indicators with tooltip */
+        .call-indicator, .backup-indicator {
             display: inline-flex;
-            flex-direction: column;
             align-items: center;
-            line-height: 1;
-            min-width: 1.5em; /* Prevent icon and text from collapsing */
-        }
-        .call-date-range {
-            display: block;
+            justify-content: center;
+            border-radius: 50%;
+            font-weight: 700;
             font-size: 0.6em;
-            line-height: 1;
-            margin-top: 0.1em; /* Give a little space below the icon */
+            position: relative;
+            margin-left: 0.25rem;
         }
-        .backup-call-icon-inline {
-            margin-left: 0.15rem;
-            font-size: 0.6em;
-            color: #6b7280; /* gray-600 for subtle indication */
-            vertical-align: super;
+        .call-indicator {
+            width: 1.1rem;
+            height: 1.1rem;
+            background: linear-gradient(135deg, var(--mizzou-gold) 0%, var(--mizzou-gold-dark) 100%);
+            color: var(--mizzou-black);
+        }
+        .backup-indicator {
+            width: 0.9rem;
+            height: 0.9rem;
+            background: #64748b;
+            color: #ffffff;
+        }
+        .indicator-tooltip {
+            position: absolute;
+            bottom: 125%;
+            left: 50%;
+            transform: translateX(-50%);
+            background: rgba(15, 15, 15, 0.95);
+            color: white;
+            padding: 0.25rem 0.5rem;
+            border-radius: 0.25rem;
+            font-size: 0.7rem;
+            white-space: nowrap;
+            opacity: 0;
+            pointer-events: none;
+            transition: all 0.2s ease;
+            z-index: 100;
+        }
+        .indicator-tooltip::after {
+            content: '';
+            position: absolute;
+            top: 100%;
+            left: 50%;
+            transform: translateX(-50%);
+            border: 3px solid transparent;
+            border-top-color: rgba(15, 15, 15, 0.95);
+        }
+        .call-indicator:hover .indicator-tooltip,
+        .backup-indicator:hover .indicator-tooltip,
+        .call-indicator.show-tooltip .indicator-tooltip,
+        .backup-indicator.show-tooltip .indicator-tooltip {
+            opacity: 1;
+            bottom: 140%;
+        }
+        .asterisk-note {
+            color: #000000; /* Black for visibility */
+            font-weight: bold; /* Make it stand out */
+            margin-left: 1px; /* Small space */
+            font-size: 0.9em; /* Slightly smaller than cell text */
         }
         .asterisk-note {
             color: #000000; /* Black for visibility */
@@ -539,8 +578,6 @@
         let BASE_MIN_WIDTH_FIRST_COL_PX;
         let BASE_TABLE_MIN_WIDTH_PX;
         let BASE_FONT_SIZE_HOLIDAY_CONTAINER_REM;
-        let BASE_FONT_SIZE_CALL_ICON_EM;
-        const MIN_CALL_ICON_FONT_SIZE_EM = 0.6; // Prevent call icon from becoming unreadable when zoomed out
 
         /**
          * Sets base sizing parameters based on viewport width.
@@ -555,7 +592,6 @@
                 BASE_MIN_WIDTH_FIRST_COL_PX = 70; // Slightly smaller min-width for first column
                 BASE_TABLE_MIN_WIDTH_PX = 800; // Smaller minimum width on mobile
                 BASE_FONT_SIZE_HOLIDAY_CONTAINER_REM = 0.55;
-                BASE_FONT_SIZE_CALL_ICON_EM = 0.65;
             } else { // Desktop or larger tablets
                 BASE_FONT_SIZE_TD_REM = 0.875; // Default text-sm
                 BASE_PADDING_TD_Y_REM = 0.5;
@@ -563,7 +599,6 @@
                 BASE_MIN_WIDTH_FIRST_COL_PX = 80; // Default min-width for first column
                 BASE_TABLE_MIN_WIDTH_PX = 1000; // Default minimum table width on desktop
                 BASE_FONT_SIZE_HOLIDAY_CONTAINER_REM = 0.6;
-                BASE_FONT_SIZE_CALL_ICON_EM = 0.7;
             }
         }
 
@@ -611,19 +646,41 @@
                 hc.style.fontSize = `${BASE_FONT_SIZE_HOLIDAY_CONTAINER_REM * zoomFactor}rem`;
             });
             
-            // Apply styles to call icons
-            const callIcons = table.querySelectorAll('.call-icon-inline');
-            callIcons.forEach(ci => {
-                const computedSize = BASE_FONT_SIZE_CALL_ICON_EM * zoomFactor;
-                ci.style.fontSize = `${Math.max(computedSize, MIN_CALL_ICON_FONT_SIZE_EM)}em`; // Ensure icon remains legible
+            // Apply styles to call/backup indicators
+            const callIndicators = table.querySelectorAll('.call-indicator');
+            callIndicators.forEach(ci => {
+                const baseSize = 1.1;
+                const computedSize = baseSize * (0.7 + zoomFactor * 0.3);
+                ci.style.width = `${computedSize}rem`;
+                ci.style.height = `${computedSize}rem`;
+                ci.style.fontSize = `${0.5 * (0.8 + zoomFactor * 0.2)}rem`;
             });
-            // Apply styles to backup call icons
-            const backupCallIcons = table.querySelectorAll('.backup-call-icon-inline');
-            backupCallIcons.forEach(ci => {
-                const computedSize = BASE_FONT_SIZE_CALL_ICON_EM * zoomFactor;
-                ci.style.fontSize = `${Math.max(computedSize, MIN_CALL_ICON_FONT_SIZE_EM)}em`;
+            const backupIndicators = table.querySelectorAll('.backup-indicator');
+            backupIndicators.forEach(bi => {
+                const baseSize = 0.9;
+                const computedSize = baseSize * (0.7 + zoomFactor * 0.3);
+                bi.style.width = `${computedSize}rem`;
+                bi.style.height = `${computedSize}rem`;
+                bi.style.fontSize = `${0.45 * (0.8 + zoomFactor * 0.2)}rem`;
             });
         }
+
+        function attachIndicatorTooltipHandlers(container) {
+            const indicators = container.querySelectorAll('.call-indicator, .backup-indicator');
+            indicators.forEach(ind => {
+                ind.addEventListener('click', function(e) {
+                    e.stopPropagation();
+                    document.querySelectorAll('.call-indicator.show-tooltip, .backup-indicator.show-tooltip')
+                        .forEach(el => { if (el !== ind) el.classList.remove('show-tooltip'); });
+                    ind.classList.toggle('show-tooltip');
+                });
+            });
+        }
+
+        document.addEventListener('click', () => {
+            document.querySelectorAll('.call-indicator.show-tooltip, .backup-indicator.show-tooltip')
+                .forEach(el => el.classList.remove('show-tooltip'));
+        });
 
 
         /**
@@ -1034,12 +1091,11 @@
                     const cellFellows = cellContent.split('&');
                     if (cellFellows.some(cf => ALL_FELLOWS.includes(cf) && cf === fellowOnCallThisWeek)) {
                         const callRangeStr = callInfo ? callInfo.callRange : '';
-                        cellHtml += ` <span class="call-icon-inline">📞<span class="call-date-range">${callRangeStr}</span></span>`;
+                        cellHtml += ` <span class="call-indicator">C<span class="indicator-tooltip">On Call: ${callRangeStr}</span></span>`;
                     }
-                    // Add backup call indicator if this fellow is backup
                     if (cellFellows.some(cf => ALL_FELLOWS.includes(cf) && cf === fellowOnBackupCallThisWeek)) {
                         const backupRangeStr = backupCallInfo ? backupCallInfo.callRange : '';
-                        cellHtml += ` <sup class="backup-call-icon-inline" title="Backup ${backupRangeStr}">B</sup>`;
+                        cellHtml += ` <span class="backup-indicator">B<span class="indicator-tooltip">Backup: ${backupRangeStr}</span></span>`;
                     }
                     
                     // Add asterisk for specific holiday coverage
@@ -1092,10 +1148,11 @@
             });
             table.appendChild(tbody);
             scheduleDisplayContainer.appendChild(table);
-            
-            applyZoomStyles(currentZoomLevel);
 
-            if (shouldScroll && currentWeekRowElementForScroll) { 
+            applyZoomStyles(currentZoomLevel);
+            attachIndicatorTooltipHandlers(scheduleDisplayContainer);
+
+            if (shouldScroll && currentWeekRowElementForScroll) {
                 attemptScrollToElement(currentWeekRowElementForScroll);
             }
         }
@@ -1194,11 +1251,11 @@
                 
                 const callInfoForWeek = callScheduleMap[weekString];
                 if (callInfoForWeek && fellowInitial === callInfoForWeek.fellow) {
-                    rotationCellContent += ` <span class="call-icon-inline">📞<span class="call-date-range">${callInfoForWeek.callRange}</span></span>`;
+                    rotationCellContent += ` <span class="call-indicator">C<span class="indicator-tooltip">On Call: ${callInfoForWeek.callRange}</span></span>`;
                 }
                 const backupCallInfoForWeek = backupCallScheduleMap[weekString];
                 if (backupCallInfoForWeek && fellowInitial === backupCallInfoForWeek.fellow) {
-                    rotationCellContent += ` <sup class="backup-call-icon-inline" title="Backup ${backupCallInfoForWeek.callRange}">B</sup>`;
+                    rotationCellContent += ` <span class="backup-indicator">B<span class="indicator-tooltip">Backup: ${backupCallInfoForWeek.callRange}</span></span>`;
                 }
                 
                 let hasSpecificHolidayCoverage = false;
@@ -1230,9 +1287,10 @@
             });
             table.appendChild(tbody);
             scheduleDisplayContainer.appendChild(table);
-            
+
 
             applyZoomStyles(currentZoomLevel);
+            attachIndicatorTooltipHandlers(scheduleDisplayContainer);
 
             if (shouldScroll && currentWeekRowElementForHighlight) {
                  attemptScrollToElement(currentWeekRowElementForHighlight);


### PR DESCRIPTION
## Summary
- redesign call and backup indicators as circles with tooltips
- scale indicators with zoom
- show tooltip on tap for mobile via new JS handlers

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685b29387ca0833388e9843fc0cba881