### PR TITLE
Update call indicator design

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
         :root {
             --mizzou-black: #000000;
             --mizzou-gold: #FFB612;
+            --mizzou-gold-dark: #C99700;
             --mizzou-gray: #f8f8f8;
             --mizzou-gray-row: #f2f2f2;
             --mizzou-hover-gold: #FFF8E1;
@@ -218,16 +219,19 @@
             margin-left: 0.25rem;
         }
         .call-indicator {
-            width: 1.1rem;
-            height: 1.1rem;
+            width: 1.2rem;
+            height: 1.2rem;
             background: linear-gradient(135deg, var(--mizzou-gold) 0%, var(--mizzou-gold-dark) 100%);
             color: var(--mizzou-black);
+            border: 1px solid var(--mizzou-gold-dark);
+            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
         }
         .backup-indicator {
-            width: 0.9rem;
-            height: 0.9rem;
+            width: 0.75rem;
+            height: 0.75rem;
             background: #64748b;
             color: #ffffff;
+            font-size: 0.55em;
         }
         .indicator-tooltip {
             position: absolute;
@@ -375,6 +379,13 @@
             text-align: center;
             font-weight: bold;
         }
+        .legend-indicator {
+            font-size: 0.55rem;
+        }
+        #legend-popover .call-indicator,
+        #legend-popover .backup-indicator {
+            margin-left: 0;
+        }
         /* Compact layout tweaks for small screens */
         @media (max-width: 639px) {
             .controls-wrapper { margin-bottom: 0.75rem; }
@@ -415,8 +426,8 @@
                             <label for="zoom-slider">Zoom Table:</label> <input type="range" id="zoom-slider" min="0.3" max="1.0" value="1" step="0.05"> <span id="zoom-value">100%</span> </div>
                          <div class="legend-button-wrapper">
                             <button id="legend-toggle-btn">Legend ℹ️</button>
-                            <div id="legend-popover" class="hidden absolute mt-1"> <p><span class="legend-symbol">📞</span> = On Call</p>
-                                <p><span class="legend-symbol" style="color:#6b7280;">B</span> = Backup Call <small>(hover for dates)</small></p>
+                            <div id="legend-popover" class="hidden absolute mt-1"> <p><span class="legend-symbol"><span class="call-indicator legend-indicator">C</span></span> = On Call</p>
+                                <p><span class="legend-symbol"><span class="backup-indicator legend-indicator">B</span></span> = Backup Call <small>(hover for dates)</small></p>
                                 <p class="mt-1"><em>Note: Call starts Friday 4:30 PM of the preceding week and ends Friday morning of the listed week.</em></p>
                                 <hr class="my-2">
                                 <p><strong>Specific Holiday Coverage:</strong></p>


### PR DESCRIPTION
## Summary
- add `--mizzou-gold-dark` color variable
- restyle the call circle and shrink backup "B"
- adjust legend to show styled `C` and smaller `B`

## Testing
- `tidy -errors index.html`

------
https://chatgpt.com/codex/tasks/task_e_685b41143544833395f8dcf0fe44ab19