### PR TITLE
Adjust call/backup indicator size

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,12 +221,12 @@
             justify-content: center;
             border-radius: 50%;
             font-weight: 700;
-            font-size: 0.5em;
+            font-size: 0.375em;
             position: absolute;
         }
         .call-indicator {
-            width: 0.85em;
-            height: 0.85em;
+            width: 1.06em;
+            height: 1.06em;
             top: -0.4em;
             right: -0.4em;
             background: linear-gradient(135deg, var(--mizzou-gold) 0%, var(--mizzou-gold-dark) 100%);
@@ -235,8 +235,8 @@
             box-shadow: 0 1px 2px rgba(0,0,0,0.3);
         }
         .backup-indicator {
-            width: 0.65em;
-            height: 0.65em;
+            width: 0.81em;
+            height: 0.81em;
             top: -0.35em;
             right: -0.35em;
             background: #64748b;


### PR DESCRIPTION
## Summary
- tweak indicator CSS so `C` and `B` circles are larger and the letter smaller

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b4f6df4ec833395a65a6afdd0d0b6