### PR TITLE
Switch to dot call indicators

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,31 +216,19 @@
 
         /* Call/Backup indicators with tooltip */
         .call-indicator, .backup-indicator {
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            border-radius: 50%;
-            font-weight: 700;
-            font-size: 0.375em;
             position: absolute;
+            font-size: 0.8em;
+            line-height: 1;
         }
         .call-indicator {
-            width: 1.2em;
-            height: 1.2em;
-            top: -0.47em;
-            right: -0.47em;
-            background: linear-gradient(135deg, var(--mizzou-gold) 0%, var(--mizzou-gold-dark) 100%);
-            color: var(--mizzou-black);
-            border: 1px solid var(--mizzou-gold-dark);
-            box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+            top: -0.3em;
+            right: -0.3em;
+            color: var(--mizzou-gold-dark);
         }
         .backup-indicator {
-            width: 1em;
-            height: 1em;
-            top: -0.45em;
-            right: -0.45em;
-            background: #64748b;
-            color: #000000; /* Improved contrast */
+            top: -0.3em;
+            right: -0.3em;
+            color: #3b82f6;
         }
         .indicator-tooltip {
             position: absolute;
@@ -438,8 +426,8 @@
                             <label for="zoom-slider">Zoom Table:</label> <input type="range" id="zoom-slider" min="0.3" max="1.0" value="1" step="0.05"> <span id="zoom-value">100%</span> </div>
                          <div class="legend-button-wrapper">
                             <button id="legend-toggle-btn">Legend ℹ️</button>
-                            <div id="legend-popover" class="hidden absolute mt-1"> <p><span class="legend-symbol"><span class="call-indicator legend-indicator">C</span></span> = On Call <small>(hover for dates)</small></p>
-                                <p><span class="legend-symbol"><span class="backup-indicator legend-indicator">B</span></span> = Backup Call <small>(hover for dates)</small></p>
+                            <div id="legend-popover" class="hidden absolute mt-1"> <p><span class="legend-symbol"><span class="call-indicator legend-indicator">●</span></span> = On Call <small>(hover for dates)</small></p>
+                                <p><span class="legend-symbol"><span class="backup-indicator legend-indicator">●</span></span> = Backup Call <small>(hover for dates)</small></p>
                                 <p class="mt-1"><em>Note: Call starts Friday 4:30 PM of the preceding week and ends Friday morning of the listed week.</em></p>
                                 <hr class="my-2">
                                 <p><strong>Specific Holiday Coverage:</strong></p>
@@ -1097,11 +1085,11 @@
                     const cellFellows = cellContent.split('&');
                     if (cellFellows.some(cf => ALL_FELLOWS.includes(cf) && cf === fellowOnCallThisWeek)) {
                         const callRangeStr = callInfo ? callInfo.callRange : '';
-                        cellHtml += ` <span class="call-indicator">C<span class="indicator-tooltip">On Call: ${callRangeStr}</span></span>`;
+                        cellHtml += ` <span class="call-indicator">●<span class="indicator-tooltip">On Call: ${callRangeStr}</span></span>`;
                     }
                     if (cellFellows.some(cf => ALL_FELLOWS.includes(cf) && cf === fellowOnBackupCallThisWeek)) {
                         const backupRangeStr = backupCallInfo ? backupCallInfo.callRange : '';
-                        cellHtml += ` <span class="backup-indicator">B<span class="indicator-tooltip">Backup: ${backupRangeStr}</span></span>`;
+                        cellHtml += ` <span class="backup-indicator">●<span class="indicator-tooltip">Backup: ${backupRangeStr}</span></span>`;
                     }
                     
                     // Add asterisk for specific holiday coverage
@@ -1258,11 +1246,11 @@
                 
                 const callInfoForWeek = callScheduleMap[weekString];
                 if (callInfoForWeek && fellowInitial === callInfoForWeek.fellow) {
-                    rotationCellContent += ` <span class="call-indicator">C<span class="indicator-tooltip">On Call: ${callInfoForWeek.callRange}</span></span>`;
+                    rotationCellContent += ` <span class="call-indicator">●<span class="indicator-tooltip">On Call: ${callInfoForWeek.callRange}</span></span>`;
                 }
                 const backupCallInfoForWeek = backupCallScheduleMap[weekString];
                 if (backupCallInfoForWeek && fellowInitial === backupCallInfoForWeek.fellow) {
-                    rotationCellContent += ` <span class="backup-indicator">B<span class="indicator-tooltip">Backup: ${backupCallInfoForWeek.callRange}</span></span>`;
+                    rotationCellContent += ` <span class="backup-indicator">●<span class="indicator-tooltip">Backup: ${backupCallInfoForWeek.callRange}</span></span>`;
                 }
                 
                 let hasSpecificHolidayCoverage = false;


### PR DESCRIPTION
## Summary
- simplify call indicator and backup indicator visuals
- swap C/B letters for gold/blue dots

## Testing
- `npm test` *(fails: missing `package.json`)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685b5baaf9e88333896c00cbff4e3856