### PR TITLE
Update call and backup indicators

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,61 +207,49 @@
         .current-week-highlight td { background-color: var(--mizzou-hover-gold) !important; }
         .current-week-highlight td:first-child { background-color: var(--mizzou-hover-gold) !important; }
         
-        /* Wrapper around cell content so indicators can be positioned */
-        .cell-wrapper {
-            position: relative;
+        /* New styles for call/backup badges */
+        .initials-call {
+            background-color: #FFB612; /* Mizzou Gold */
+            color: #000000;
+            padding: 1px 4px;
+            border-radius: 3px;
+            font-weight: 600;
+            cursor: help;
             display: inline-block;
-            padding-right: 0.35em; /* space for indicator */
         }
 
-        /* Call/Backup indicators with tooltip */
-        .call-indicator, .backup-indicator {
-            position: absolute;
-            font-size: 0.8em;
-            line-height: 1;
-        }
-        .call-indicator {
-            top: -0.3em;
-            right: -0.3em;
-            color: var(--mizzou-gold-dark);
-        }
-        .backup-indicator {
-            top: -0.3em;
-            right: -0.3em;
-            color: #3b82f6;
-        }
-        .indicator-tooltip {
-            position: absolute;
-            bottom: 125%;
-            left: 50%;
-            transform: translateX(-50%);
-            background: rgba(15, 15, 15, 0.95);
+        .initials-backup {
+            background-color: #4682B4; /* Steel Blue */
             color: white;
-            padding: 0.25rem 0.5rem;
-            border-radius: 0.25rem;
-            font-size: 0.7rem;
-            white-space: nowrap;
-            opacity: 0;
-            pointer-events: none;
-            transition: all 0.2s ease;
-            z-index: 100;
+            padding: 1px 4px;
+            border-radius: 3px;
+            font-weight: 600;
+            cursor: help;
+            display: inline-block;
         }
-        .indicator-tooltip::after {
-            content: '';
-            position: absolute;
-            top: 100%;
-            left: 50%;
-            transform: translateX(-50%);
-            border: 3px solid transparent;
-            border-top-color: rgba(15, 15, 15, 0.95);
+
+        .initials-both {
+            background: linear-gradient(135deg, #FFB612 50%, #4682B4 50%);
+            color: white;
+            padding: 1px 4px;
+            border-radius: 3px;
+            font-weight: 700;
+            cursor: help;
+            text-shadow: 1px 1px 2px rgba(0,0,0,0.5);
+            display: inline-block;
         }
-        .call-indicator:hover .indicator-tooltip,
-        .backup-indicator:hover .indicator-tooltip,
-        .call-indicator.show-tooltip .indicator-tooltip,
-        .backup-indicator.show-tooltip .indicator-tooltip {
-            opacity: 1;
-            bottom: 140%;
-        }
+
+        /* Old indicator styles are no longer used */
+        /*
+        .cell-wrapper { ... }
+        .call-indicator { ... }
+        .backup-indicator { ... }
+        .indicator-tooltip { ... }
+        .call-indicator:hover .indicator-tooltip { ... }
+        .backup-indicator:hover .indicator-tooltip { ... }
+        .call-indicator.show-tooltip .indicator-tooltip { ... }
+        .backup-indicator.show-tooltip .indicator-tooltip { ... }
+        */
         .asterisk-note {
             color: #000000; /* Black for visibility */
             font-weight: bold; /* Make it stand out */
@@ -426,8 +414,10 @@
                             <label for="zoom-slider">Zoom Table:</label> <input type="range" id="zoom-slider" min="0.3" max="1.0" value="1" step="0.05"> <span id="zoom-value">100%</span> </div>
                          <div class="legend-button-wrapper">
                             <button id="legend-toggle-btn">Legend ℹ️</button>
-                            <div id="legend-popover" class="hidden absolute mt-1"> <p><span class="legend-symbol"><span class="call-indicator legend-indicator">●</span></span> = On Call <small>(hover for dates)</small></p>
-                                <p><span class="legend-symbol"><span class="backup-indicator legend-indicator">●</span></span> = Backup Call <small>(hover for dates)</small></p>
+                            <div id="legend-popover" class="hidden absolute mt-1">
+                                <p><span class="initials-call" style="font-size: 0.8em; padding: 1px 3px;">XX</span> = On Call</p>
+                                <p><span class="initials-backup" style="font-size: 0.8em; padding: 1px 3px;">XX</span> = Backup Call</p>
+                                <p><span class="initials-both" style="font-size: 0.8em; padding: 1px 3px;">XX</span> = On Call + Backup</p>
                                 <p class="mt-1"><em>Note: Call starts Friday 4:30 PM of the preceding week and ends Friday morning of the listed week.</em></p>
                                 <hr class="my-2">
                                 <p><strong>Specific Holiday Coverage:</strong></p>
@@ -659,22 +649,7 @@
             
         }
 
-        function attachIndicatorTooltipHandlers(container) {
-            const indicators = container.querySelectorAll('.call-indicator, .backup-indicator');
-            indicators.forEach(ind => {
-                ind.addEventListener('click', function(e) {
-                    e.stopPropagation();
-                    document.querySelectorAll('.call-indicator.show-tooltip, .backup-indicator.show-tooltip')
-                        .forEach(el => { if (el !== ind) el.classList.remove('show-tooltip'); });
-                    ind.classList.toggle('show-tooltip');
-                });
-            });
-        }
-
-        document.addEventListener('click', () => {
-            document.querySelectorAll('.call-indicator.show-tooltip, .backup-indicator.show-tooltip')
-                .forEach(el => el.classList.remove('show-tooltip'));
-        });
+        /* Custom tooltip handlers for call indicators are no longer required */
 
 
         /**
@@ -1079,18 +1054,26 @@
                 mainScheduleHeaders.forEach((header, hIndex) => {
                     const td = document.createElement('td');
                     const cellContent = weekData[header] || '-'; // Default to '-' if empty
-                    let cellHtml = `<span class="cell-wrapper">${cellContent}`;
-
-                    // Add call icon if this fellow is on call
                     const cellFellows = cellContent.split('&');
-                    if (cellFellows.some(cf => ALL_FELLOWS.includes(cf) && cf === fellowOnCallThisWeek)) {
-                        const callRangeStr = callInfo ? callInfo.callRange : '';
-                        cellHtml += ` <span class="call-indicator">●<span class="indicator-tooltip">On Call: ${callRangeStr}</span></span>`;
-                    }
-                    if (cellFellows.some(cf => ALL_FELLOWS.includes(cf) && cf === fellowOnBackupCallThisWeek)) {
-                        const backupRangeStr = backupCallInfo ? backupCallInfo.callRange : '';
-                        cellHtml += ` <span class="backup-indicator">●<span class="indicator-tooltip">Backup: ${backupRangeStr}</span></span>`;
-                    }
+                    let decoratedFellows = cellFellows.map(cfRaw => {
+                        const cf = cfRaw.trim();
+                        let decorated = cf;
+                        if (ALL_FELLOWS.includes(cf)) {
+                            const isCall = cf === fellowOnCallThisWeek;
+                            const isBackup = cf === fellowOnBackupCallThisWeek;
+                            const callRangeStr = callInfo ? callInfo.callRange : '';
+                            const backupRangeStr = backupCallInfo ? backupCallInfo.callRange : '';
+                            if (isCall && isBackup) {
+                                decorated = `<span class="initials-both" title="On Call + Backup: ${callRangeStr}">${cf}</span>`;
+                            } else if (isCall) {
+                                decorated = `<span class="initials-call" title="On Call: ${callRangeStr}">${cf}</span>`;
+                            } else if (isBackup) {
+                                decorated = `<span class="initials-backup" title="Backup: ${backupRangeStr}">${cf}</span>`;
+                            }
+                        }
+                        return decorated;
+                    });
+                    let cellHtml = decoratedFellows.join('&');
                     
                     // Add asterisk for specific holiday coverage
                     cellFellows.forEach(cf => {
@@ -1116,7 +1099,6 @@
                             }
                         }
                     });
-                    cellHtml += '</span>'; // close cell-wrapper
                     
                     if (hIndex === 0) { // First column (Week)
                         td.innerHTML = `<span class="week-cell-content">${cellContent}</span>`; // Wrap week string
@@ -1145,7 +1127,6 @@
             scheduleDisplayContainer.appendChild(table);
 
             applyZoomStyles(currentZoomLevel);
-            attachIndicatorTooltipHandlers(scheduleDisplayContainer);
 
             if (shouldScroll && currentWeekRowElementForScroll) {
                 attemptScrollToElement(currentWeekRowElementForScroll);
@@ -1286,7 +1267,6 @@
 
 
             applyZoomStyles(currentZoomLevel);
-            attachIndicatorTooltipHandlers(scheduleDisplayContainer);
 
             if (shouldScroll && currentWeekRowElementForHighlight) {
                  attemptScrollToElement(currentWeekRowElementForHighlight);


### PR DESCRIPTION
## Summary
- swap old call/backup indicators for colored badge styles
- drop tooltip JS and calls
- update legend to show badge samples

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b5d7c9ab88333863d973f5bb15dd6