### PR TITLE
Add weekly schedule button

### DIFF
--- a/index.html
+++ b/index.html
@@ -467,6 +467,7 @@
                                 <option value="all">Show All Schedules</option>
                                 </select>
                             <button id="export-ics-btn" class="action-btn hidden" title="Export to iCalendar (.ics)">🗓️ Export ICS</button>
+                            <a id="weekly-schedule-btn" class="action-btn ml-2" href="https://www.weekly.mizzougi.com" target="_blank" rel="noopener">Weekly Schedule</a>
                         </div>
                     </div>
                     <div class="flex flex-col items-start sm:items-end mt-4 sm:mt-0">


### PR DESCRIPTION
## Summary
- add a Weekly Schedule button next to the ICS export

## Testing
- `curl -I https://www.weekly.mizzougi.com | head -n 5` (fails: blocked)

------
https://chatgpt.com/codex/tasks/task_e_6863f4aecdb88333964a018987b252d9