### PR TITLE
Fix weekly schedule link behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -467,7 +467,7 @@
                                 <option value="all">Show All Schedules</option>
                                 </select>
                             <button id="export-ics-btn" class="action-btn hidden" title="Export to iCalendar (.ics)">🗓️ Export ICS</button>
-                            <a id="weekly-schedule-btn" class="action-btn ml-2" href="https://weekly.mizzougi.com" target="_blank" rel="noopener">Weekly Schedule</a>
+                            <a id="weekly-schedule-btn" class="action-btn ml-2" href="https://weekly.mizzougi.com" rel="noopener">Weekly Schedule</a>
                         </div>
                     </div>
                     <div class="flex flex-col items-start sm:items-end mt-4 sm:mt-0">


### PR DESCRIPTION
## Summary
- keep weekly schedule link in the same tab

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68650d1de3b88333ba383648d10dc75f