### PR TITLE
Fix missing H badge on Juneteenth

### DIFF
--- a/index.html
+++ b/index.html
@@ -490,7 +490,7 @@
                                 <p><span class="legend-symbol holiday-badge">H</span> IM: Thanksgiving (Nov 27, 2025)</p>
                                 <p><span class="legend-symbol holiday-badge">H</span> AA: Christmas (Dec 25, 2025), Memorial Day (May 26, 2025)</p>
                                 <p><span class="legend-symbol holiday-badge">H</span> EZ: Black Friday (Nov 28, 2025), MLK Day (Jan 19, 2026)</p>
-                                <p><span class="legend-symbol holiday-badge">H</span> AM: Juneteenth (Jun 19, 2025)</p>
+                                <p><span class="legend-symbol holiday-badge">H</span> AM: Juneteenth (Jun 19, 2025 &amp; Jun 19, 2026)</p>
                                 <p><span class="legend-symbol holiday-badge">H</span> MD: New Year's Day (Jan 1, 2026)</p>
                                 <hr class="my-1">
                                 <p><span class="legend-symbol weekend-badge">W</span> Last Weekend Call (MD, AM)</p>
@@ -609,6 +609,7 @@
             { fellow: 'EZ', holidayName: "Black Friday", date: new Date(2025, 10, 28) },
             { fellow: 'EZ', holidayName: "MLK Day", date: new Date(2026, 0, 19) },
             { fellow: 'AM', holidayName: "Juneteenth", date: new Date(2025, 5, 19) },
+            { fellow: 'AM', holidayName: "Juneteenth", date: new Date(2026, 5, 19) },
             { fellow: 'MD', holidayName: "New Year's Day", date: new Date(2026, 0, 1) }
         ];
         specificHolidayCoverage.forEach(h => h.date.setHours(0,0,0,0));


### PR DESCRIPTION
## Summary
- show Juneteenth coverage for AM on both 2025 and 2026

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68697be16580833389eff44ee71a0168